### PR TITLE
fix: remove the cache scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.platform</groupId>
     <artifactId>gravitee-platform-repository-api</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-archi-231-cache-manager-SNAPSHOT</version>
 
     <name>Gravitee.io Platform - Repository - API</name>
 

--- a/src/main/java/io/gravitee/platform/repository/api/Scope.java
+++ b/src/main/java/io/gravitee/platform/repository/api/Scope.java
@@ -28,7 +28,6 @@ public enum Scope {
     MANAGEMENT("management"),
     RATE_LIMIT("ratelimit"),
     ANALYTICS("analytics"),
-    CACHE("cache"),
     KEY_VALUE("keyvalue");
 
     String name;


### PR DESCRIPTION

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-231

**Description**

Use newest cache manager plugin and the cache scope is clashing with the new cache manager plugin and is not used anymore.


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1-archi-231-cache-manager-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/platform/gravitee-platform-repository-api/1.2.1-archi-231-cache-manager-SNAPSHOT/gravitee-platform-repository-api-1.2.1-archi-231-cache-manager-SNAPSHOT.zip)
  <!-- Version placeholder end -->
