### PR TITLE
ARCHI-217 add new Repository Scope for DistributedSync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.platform</groupId>
     <artifactId>gravitee-platform-repository-api</artifactId>
-    <version>1.2.1</version>
+    <version>1.3.0-archi-217-distributed-sync-SNAPSHOT</version>
 
     <name>Gravitee.io Platform - Repository - API</name>
 

--- a/src/main/java/io/gravitee/platform/repository/api/RepositoryScopeProvider.java
+++ b/src/main/java/io/gravitee/platform/repository/api/RepositoryScopeProvider.java
@@ -27,4 +27,15 @@ public interface RepositoryScopeProvider {
      * @see Scope
      */
     Scope[] getHandledScopes();
+
+    /**
+     * Repository implementations must implement this method in order to list all the optional repository scopes they can handle.
+     * Any missing scope configuration will be ignored.
+     *
+     * @return all the repository scopes optionally handled.
+     * @see Scope
+     */
+    default Scope[] getOptionalHandledScopes() {
+        return new Scope[] {};
+    }
 }

--- a/src/main/java/io/gravitee/platform/repository/api/Scope.java
+++ b/src/main/java/io/gravitee/platform/repository/api/Scope.java
@@ -28,7 +28,8 @@ public enum Scope {
     MANAGEMENT("management"),
     RATE_LIMIT("ratelimit"),
     ANALYTICS("analytics"),
-    KEY_VALUE("keyvalue");
+    KEY_VALUE("keyvalue"),
+    DISTRIBUTED_SYNC("distributed-sync");
 
     String name;
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-217

**Description**

add new Repository Scope for DistributedSync
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.0-archi-217-distributed-sync-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/platform/gravitee-platform-repository-api/1.3.0-archi-217-distributed-sync-SNAPSHOT/gravitee-platform-repository-api-1.3.0-archi-217-distributed-sync-SNAPSHOT.zip)
  <!-- Version placeholder end -->
