### PR TITLE
chore: update renovate config to use presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,3 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+  "extends": ["github>gravitee-io/renovate-config:lib"]
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-300

**Description**

Update the renovate config to match the shared presets defined.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/platform/gravitee-platform-repository-api/1.4.0/gravitee-platform-repository-api-1.4.0.zip)
  <!-- Version placeholder end -->
